### PR TITLE
Remove unnecessary socket and environment variables

### DIFF
--- a/eu.jumplink.Learn6502.json
+++ b/eu.jumplink.Learn6502.json
@@ -15,9 +15,7 @@
     "--device=dri",
     "--share=ipc",
     "--socket=fallback-x11",
-    "--socket=wayland",
-    "--socket=pulseaudio",
-    "--env=GJS_DISABLE_JIT=1"
+    "--socket=wayland"
   ],
   "cleanup": [
     "/include",


### PR DESCRIPTION
The app does not need access to pulseaudio and GJS Just-In-Time compilation is also fine.