### PR TITLE
Update runtime to 50 and more

### DIFF
--- a/eu.jumplink.Learn6502.json
+++ b/eu.jumplink.Learn6502.json
@@ -1,7 +1,7 @@
 {
     "id": "eu.jumplink.Learn6502",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.node24",
@@ -17,36 +17,7 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a",
-        "*.map",
-        "*.d.ts",
-        "*.js.map"
-    ],
     "modules": [
-        {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "builddir": true,
-            "cleanup": [
-                "*"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler/-/archive/v0.20.0/blueprint-compiler-v0.20.0.tar.gz",
-                    "sha256": "b6d43b474557dc5c591cca693f6d8a82e328fd125261a7e4fe702f2818106427"
-                }
-            ]
-        },
         {
             "name": "Learn6502",
             "buildsystem": "meson",

--- a/eu.jumplink.Learn6502.json
+++ b/eu.jumplink.Learn6502.json
@@ -26,15 +26,13 @@
                     "type": "git",
                     "url": "https://github.com/JumpLink/Learn6502.git",
                     "tag": "v0.6.4",
+                    "commit": "b36928c57ce4a5b4654f5f686f719c3fcb80473b",
+                    "disable-submodules": true,
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v(\\d+\\.\\d+\\.\\d+)$",
-                        "version-scheme": "semantic",
-                        "is-main-source": true,
-                        "is-important": true
-                    },
-                    "commit": "b36928c57ce4a5b4654f5f686f719c3fcb80473b",
-                    "disable-submodules": true
+                        "version-scheme": "semantic"
+                    }
                 }
             ]
         }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "require-important-update": true
-}


### PR DESCRIPTION
### Update runtime to 50

- Update the runtime version to 50
- Use the blueprint-compiler module from the runtime
- Drop ineffective cleanup commands

### Remove require-important-update tag

- Since only one module remained, this definition became redundant and was therefore removed.

